### PR TITLE
Clamp against the display the swipe lands on, not the focused one

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,18 @@ scratch build rather than trusting a green run.
 **`setup`/`teardown` change system settings and restart the Dock.** If you toggle them
 while testing, restore the user's original state before you finish.
 
+**Space switching follows the cursor, not keyboard focus.** The Dock routes a Dock-swipe
+to the display under the mouse pointer, and native Ctrl+arrow routes the same way —
+hovering a second display, with no click and no focus change, makes it the target.
+`SLSGetActiveSpace` and `SLSCopyActiveMenuBarDisplayIdentifier` track keyboard focus
+instead, so they are the wrong input for anything that must agree with where a swipe will
+land; using them for the boundary clamp was issue #3. The swipe cannot be *steered*
+either: the 27 path carries `fieldSwipePositionX/Y`, but the pre-27 path has no position
+field, so only the clamp can be made to follow. When testing multi-display, pin the cursor
+explicitly with `CGWarpMouseCursorPosition` — otherwise results depend on wherever you
+happened to leave it. Only relevant with "Displays have separate Spaces" on; with it off
+every screen shares one space list.
+
 **Nothing secret belongs in this repo.** Signing material lives in
 `~/.config/noswoosh-signing/` and in CI secrets. The `.p12` must be exported with
 legacy PBE flags (`-keypbe PBE-SHA1-3DES -certpbe PBE-SHA1-3DES -macalg sha1`) or

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ Two ways to switch, both instant:
 
 Movement is clamped at the first and last space, so there's no rubber-band bounce.
 
+Multi-display works exactly as it does without noswoosh: the switch applies to the
+display under the pointer, not the one holding keyboard focus. With "Displays have
+separate Spaces" off, all displays share one set and move together.
+
 A CLI is available for scripting and debugging:
 
 ```sh

--- a/noswoosh.swift
+++ b/noswoosh.swift
@@ -45,7 +45,7 @@ import ApplicationServices
 // Build: swiftc noswoosh.swift -O -o noswoosh \
 //          -F /System/Library/PrivateFrameworks -framework SkyLight
 
-let noswooshVersion = "1.7.1"
+let noswooshVersion = "1.7.2"
 
 // MARK: - Setup / teardown (system configuration, all user-level)
 
@@ -103,23 +103,65 @@ func SLSCopySpacesForWindows(_ cid: CGSConnectionID, _ mask: Int32,
 
 let cid = SLSMainConnectionID()
 
-struct SpaceInfo { let ids: [UInt64]; let currentIndex: Int }
+struct SpaceInfo {
+    let ids: [UInt64]
+    let currentIndex: Int
+    // "Display Identifier" of the display this list belongs to, so a prediction
+    // made on one display is never applied to another's list.
+    let display: String?
+}
 
-// Space list for the display that owns the currently active space, plus the
-// active space's index in it. Keying off the global active space (not
-// displays.first) keeps boundary math correct on multi-display setups, where the
-// switch lands on whichever display has focus. On a single display this is
-// exactly the first display. The list includes fullscreen spaces, which the
+// UUID string of the display under the mouse cursor, in the same form as the
+// "Display Identifier" values in SLSCopyManagedDisplaySpaces. A CGEvent's
+// location is already in global CG coordinates, so this needs no flip from
+// Cocoa's bottom-left origin.
+func cursorDisplayUUID() -> String? {
+    guard let location = CGEvent(source: nil)?.location else { return nil }
+    var displayID = CGDirectDisplayID()
+    var matched: UInt32 = 0
+    guard CGGetDisplaysWithPoint(location, 1, &displayID, &matched) == .success,
+          matched > 0,
+          let uuid = CGDisplayCreateUUIDFromDisplayID(displayID)?.takeRetainedValue()
+    else { return nil }
+    return CFUUIDCreateString(nil, uuid) as String
+}
+
+// Space list for the display the switch will actually land on, plus that
+// display's current index in it. The list includes fullscreen spaces, which the
 // swipe traverses too.
+//
+// The Dock routes a Dock-swipe to the display under the *mouse cursor*, not the
+// one holding keyboard focus — native Ctrl+arrow routes the same way, so merely
+// hovering a display makes it the target. SLSGetActiveSpace tracks keyboard
+// focus instead, so clamping against it guards the wrong list whenever cursor
+// and focus sit on different displays: it either deadens a legal keypress or
+// lets through a swipe that rubber-bands. See issue #3.
 func spaceInfo() -> SpaceInfo? {
     let displays = SLSCopyManagedDisplaySpaces(cid).takeRetainedValue() as! [[String: Any]]
+
+    func info(_ display: [String: Any], current: UInt64) -> SpaceInfo? {
+        guard let spaces = display["Spaces"] as? [[String: Any]] else { return nil }
+        let ids = spaces.compactMap { ($0["id64"] as? NSNumber)?.uint64Value }
+        guard let idx = ids.firstIndex(of: current) else { return nil }
+        return SpaceInfo(ids: ids, currentIndex: idx,
+                         display: display["Display Identifier"] as? String)
+    }
+
+    // Multi-display: ask the cursor's display for its own current space. Each
+    // display dict already carries one, so this costs no extra private call.
+    if displays.count > 1, let uuid = cursorDisplayUUID(),
+       let display = displays.first(where: { ($0["Display Identifier"] as? String) == uuid }),
+       let current = (display["Current Space"] as? [String: Any])?["id64"] as? NSNumber,
+       let result = info(display, current: current.uint64Value) {
+        return result
+    }
+
+    // One managed display — a single screen, or "Displays have separate Spaces"
+    // off, where every screen shares one list — plus the fallback for a failed
+    // cursor lookup. Byte-identical to the behavior before the fix.
     let active = SLSGetActiveSpace(cid)
     for display in displays {
-        guard let spaces = display["Spaces"] as? [[String: Any]] else { continue }
-        let ids = spaces.compactMap { ($0["id64"] as? NSNumber)?.uint64Value }
-        if let idx = ids.firstIndex(of: active) {
-            return SpaceInfo(ids: ids, currentIndex: idx)
-        }
+        if let result = info(display, current: active) { return result }
     }
     return nil
 }
@@ -329,6 +371,7 @@ func postPair(_ dock: CGEvent) {
 // stale. Trust our own prediction for a short window after a switch. macOS 27's
 // list settles slower after a synthetic switch, so give it a wider window.
 var predictedIndex: Int?
+var predictedDisplay: String?
 var predictionTime = Date.distantPast
 let predictionWindow = needsAugmentation ? 0.4 : 0.25
 
@@ -360,7 +403,9 @@ func switchSpace(right: Bool) {
     var current = info.currentIndex
     // Prefer our prediction while the list may still be catching up, so a rapid
     // second switch is not blocked by a stale "you're at the edge" reading.
-    if let p = predictedIndex, Date().timeIntervalSince(predictionTime) < predictionWindow {
+    // Only on the display it was made for; the cursor may have moved since.
+    if let p = predictedIndex, predictedDisplay == info.display,
+       Date().timeIntervalSince(predictionTime) < predictionWindow {
         current = p
     }
     let target = current + (right ? 1 : -1)
@@ -369,6 +414,7 @@ func switchSpace(right: Bool) {
     guard target >= 0, target < info.ids.count else { return }
     postSwitchGesture(right: right)
     predictedIndex = target
+    predictedDisplay = info.display
     predictionTime = Date()
 }
 


### PR DESCRIPTION
Fixes #3.

## The bug

`spaceInfo()` resolved its space list via `SLSGetActiveSpace`, which tracks the **keyboard-focus** display. The Dock routes the synthetic Dock-swipe to the display under the **mouse cursor**. With two displays and "Displays have separate Spaces" on, the boundary clamp guarded a different display than the one actually being switched — so a legal keypress died at the wrong display's edge, or a swipe was let through to rubber-band at the real one.

## The fix

Resolve the list from the display under the cursor, reading that display's own `Current Space` out of `SLSCopyManagedDisplaySpaces` — each display dict already carries one, so no new private symbol is needed. Fall back to `SLSGetActiveSpace` when there is a single managed display (one screen, or separate Spaces off, where every screen shares one list) or the cursor lookup fails, leaving those paths byte-identical. The prediction is now keyed to the display it was made on, since the cursor can move between switches.

The swipe itself is untouched: it already lands on the cursor's display, which is also what native Ctrl+arrow does. Only the clamp disagreed.

## Verification

Two displays, macOS 26.6.2, left display 4 spaces / right display 2.

`noswoosh list`, which is the clamp's input:

| cursor | 1.7.1 | 1.7.2 |
|---|---|---|
| left display | `space 1 of 4` | `space 1 of 4` |
| right display | `space 1 of 4` ❌ | `space 1 of 2` ✅ |
| right display, after moving it to its last space | `space 1 of 4` ❌ | `space 2 of 2` ✅ |

End to end, cursor on the right display:

- `left` at 2 of 2 — **dead under 1.7.1**, now switches 101→89.
- `right` at 2 of 2 — **posted and bounced under 1.7.1**, now correctly clamped.
- Cursor on the left display: unchanged in both, no regression.

Native routing was confirmed by a full crossover with noswoosh stopped and symbolic hotkeys 79/81 live-enabled — in all six focus/cursor combinations the display that moved was the cursor's, never the focused one. Details in #3.

## Not covered

Spanning mode (`spans-displays = YES`) **has since been verified on hardware** after a logout — `SLSCopyManagedDisplaySpaces` returns a single `"Main"` entry, the cursor branch is skipped, and both clamp edges plus a full traversal pass. See the comments below.

Still not covered: single-display, which takes the same unchanged fallback path by construction; real 3-finger swipes, since only the hotkey and CLI paths were exercised; and macOS 27, not re-tested because the change sits above the `needsAugmentation` split and touches neither posting path.

Also adds an AGENTS.md trap so the cursor-vs-focus distinction doesn't have to be rediscovered, and bumps the version to 1.7.2 ahead of a tag.

https://claude.ai/code/session_011Qt3ZNTFywf9qKWDb17vrF
