### PR TITLE
Document the CLI as a custom-shortcut backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ noswoosh teardown
 noswoosh version
 ```
 
+For a custom shortcut, bind `noswoosh left` / `noswoosh right` in any hotkey tool that
+runs a command — [skhd](https://github.com/koekeishiya/skhd),
+[Karabiner-Elements](https://karabiner-elements.pqrs.org),
+[Hammerspoon](https://www.hammerspoon.org) or [Raycast](https://www.raycast.com). The
+switch lands in ~100ms either way, so there's no speed penalty versus the built-in
+Ctrl+←/→.
+
 ## How it works
 
 macOS has no supported way to disable *only* the space-switch slide animation:


### PR DESCRIPTION
One line in **Usage**, after the CLI block.

Custom keyboard shortcuts are the most-requested feature cluster on comparable projects — [ISS#62](https://github.com/jurplel/InstantSpaceSwitcher/issues/62) (multiple bindings), [ISS#86](https://github.com/jurplel/InstantSpaceSwitcher/issues/86) (more slots), [ISS#91](https://github.com/jurplel/InstantSpaceSwitcher/issues/91) (per-display). noswoosh already supports the general case through the CLI; it just wasn't written down anywhere, so the capability was invisible.

**Measured before claiming no penalty.** CLI path, trigger to space change: **94ms / 133ms / 121ms** over three runs. The in-process hotkey measured ~117ms during the 1.7.0 work. WindowServer's commit latency dominates and process spawn vanishes into it. The CLI's 150ms exit grace happens *after* the switch has landed, so it isn't perceived.

That's the argument for documenting rather than building: adding a config file to a zero-config app would buy nothing measurable.

Tools referenced are the ones users in those threads actually run — Karabiner-Elements and Raycast come from ISS#86, Hammerspoon from [ISS#29](https://github.com/jurplel/InstantSpaceSwitcher/issues/29), and skhd shares an author with yabai, already in Credits.

Not addressed here: direct "switch to space N" (ISS#86's real ask) is architecturally awkward, since relative single hops mean a distant jump cuts visibly through every intermediate space.

https://claude.ai/code/session_011Qt3ZNTFywf9qKWDb17vrF